### PR TITLE
Qt6/6.5.2: QT_AVOID_CMAKE_ARCHIVING_API=ON

### DIFF
--- a/easybuild/easyconfigs/q/Qt6/Qt6-6.5.2-GCCcore-12.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt6/Qt6-6.5.2-GCCcore-12.2.0.eb
@@ -56,6 +56,7 @@ dependencies = [
 
 # See qtbase/cmake/configure-cmake-mapping.md for options
 configopts = '-DQT_QMAKE_TARGET_MKSPEC=linux-g++'
+configopts += ' -DQT_AVOID_CMAKE_ARCHIVING_API=ON'
 
 sanity_check_paths = {
     'files': [


### PR DESCRIPTION
I needed this to get the compilation to work with the CMake/3.24.3-GCCcore-12.2.0.